### PR TITLE
Handle queries with nested relations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,5 +12,6 @@ module.exports = {
     }],
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'no-console': ['warn'],
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,94 @@
+# type-graph-orm
+
+Simple integration between [TypeORM](https://github.com/typeorm/typeorm) and [TypeGraphQL](https://github.com/19majkel94/type-graphql).
+
+```typescript
+import * as GraphORM from 'type-graph-orm'
+import {
+  Column,
+  Field,
+  Int,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  String,
+} from 'typeorm'
+import { graphql } from 'graphql'
+import { buildSchema } from 'type-graphql'
+
+// Define TypeORM entities
+@GraphORM.DatabaseObjectType()
+export class User {
+  @Field(() => Int)
+  @PrimaryGeneratedColumn()
+  public id: number
+
+  @Field(() => String)
+  @Column()
+  public name: string
+
+  @Field(() => Int)
+  @Column()
+  public age: number
+
+  @Field(() => [Post])
+  @OneToMany(() => Post, post => post.user)
+  public posts: Post[]
+}
+
+@GraphORM.DatabaseObjectType()
+class Post {
+  @Field(() => Int)
+  @PrimaryGeneratedColumn()
+  public id: number
+
+  @Field(() => String)
+  @Column()
+  public title: string
+
+  @Field(() => User)
+  @ManyToOne(() => User, user => user.posts)
+  public user: User
+}
+
+// Define type-graphql resolvers
+@GraphORM.Resolver({
+  queryName: 'users',
+  typeFunction: () => User,
+})
+export class UserResolver {
+}
+
+@GraphORM.Resolver({
+  queryName: 'posts',
+  typeFunction: () => Post,
+})
+export class PostResolver {
+}
+
+// Create executable schema
+const schema = await buildSchema({
+  resolvers: [
+    UserResolver,
+    PostResolver,
+  ],
+})
+
+// Run query!
+const result = await graphql(schema, `
+query {
+  users {
+    id
+    name
+    age
+    posts {
+      id
+      title
+    }
+  }
+}`)
+```
+
+## Notes
+
+Implementation is now at experimental stage. It's currently tested on the simplest cases.

--- a/__tests__/entities/post.ts
+++ b/__tests__/entities/post.ts
@@ -4,9 +4,7 @@ import { Column, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
 import * as GraphORM from '@/index'
 import { User } from './user'
 
-@GraphORM.DatabaseObjectType({
-  alias: 'post',
-})
+@GraphORM.DatabaseObjectType()
 export class Post {
   @Field(() => Int)
   @PrimaryGeneratedColumn()
@@ -16,6 +14,7 @@ export class Post {
   @Column()
   public title: string
 
+  @Field(() => User)
   @ManyToOne(() => User, user => user.posts)
   public user: User
 }

--- a/__tests__/entities/user.ts
+++ b/__tests__/entities/user.ts
@@ -4,10 +4,7 @@ import { Column, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
 import * as GraphORM from '@/index'
 import { Post } from './post'
 
-@GraphORM.DatabaseObjectType({
-  alias: 'user',
-  relations: ['posts'],
-})
+@GraphORM.DatabaseObjectType()
 export class User {
   @Field(() => Int)
   @PrimaryGeneratedColumn()

--- a/__tests__/test-basic.ts
+++ b/__tests__/test-basic.ts
@@ -7,7 +7,7 @@ import { query, setupTest } from './util'
 describe('Basic', () => {
   setupTest()
 
-  it('handles basic query', async () => {
+  async function setupFixture() {
     const conn = getConnection()
     const user = new User()
 
@@ -16,6 +16,19 @@ describe('Basic', () => {
 
     await conn.getRepository(User).save(user)
 
+    const post = new Post()
+
+    post.title = 'hello'
+    post.user = user
+
+    await conn.getRepository(Post).save(post)
+  }
+
+  beforeEach(async () => {
+    await setupFixture()
+  })
+
+  it('handles basic query', async () => {
     const result = await query(`
 query {
   users {
@@ -37,21 +50,6 @@ query {
   })
 
   it('resolves 1:n query', async () => {
-    const conn = await getConnection()
-    const user = new User()
-
-    user.age = 3
-    user.name = 'Jeong'
-
-    await conn.getRepository(User).save(user)
-
-    const post = new Post()
-
-    post.title = 'hello'
-    post.user = user
-
-    await conn.getRepository(Post).save(post)
-
     const result = await query(`
 query {
   users {
@@ -76,6 +74,45 @@ query {
           ],
         },
       ],
+    })
+  })
+
+  it('resolves recursive query', async () => {
+    const result = await query(`
+query {
+  users {
+    id
+    posts {
+      id
+      user {
+        id
+        posts {
+          title
+        }
+      }
+    }
+  }
+}`)
+
+    expect(result.data).toMatchObject({
+      users: [
+        {
+          id: expect.any(Number),
+          posts: [
+            {
+              id: expect.any(Number),
+              user: {
+                id: expect.any(Number),
+                posts: [
+                  {
+                    title: 'hello',
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      ]
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "repository": "github:JeongHoJeong/type-graph-orm",
   "author": "Jeongho Jeong <fiil12@hotmail.com>",
   "license": "MIT",
+  "keywords": [
+    "typescript",
+    "graphql",
+    "typeorm",
+    "type-graphql"
+  ],
   "files": [
     "lib"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "type-graph-orm",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "repository": "github:JeongHoJeong/type-graph-orm",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,6 @@ interface Field<T, C> {
 interface DatabaseObjectMetadata<T, C> {
   fields: Field<T, C>[]
   alias?: string
-  // TODO: deprecate `relations`. It's temporal solution that makes its users manually
-  // enter in what relations it have. This should be done automatically.
-  relations?: string[]
 }
 
 function makeDefaultDatabaseObjectMetadata<T, C>(): DatabaseObjectMetadata<T, C> {
@@ -61,18 +58,13 @@ export function Field<T, C>(options: {
   }
 }
 
-export function DatabaseObjectType({
-  alias,
-  relations,
-}: {
-  alias: string
-  relations?: string[]
+export function DatabaseObjectType(options?: {
+  alias?: string
 }): ClassDecorator {
   return (...args: Parameters<ClassDecorator>): void => {
     const [target] = args
     const metadata = getDatabaseObjectMetadata(target.prototype)
-    metadata.alias = alias
-    metadata.relations = relations
+    metadata.alias = options && options.alias
 
     TypeGraphQL.ObjectType()(target)
     TypeORM.Entity()(target)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import * as TypeGraphQL from 'type-graphql'
 import * as TypeORM from 'typeorm'
+import { GraphQLResolveInfo } from 'graphql'
+import { getRelationsForQuery } from './util'
 
 const databaseObjectMetadataKey = Symbol('databaseObjectMetadataKey')
 
@@ -124,12 +126,14 @@ export function Resolver<T, C>({
     Parameters will be used to compute context of the query and conditionally add subqueries.
     */
     async function rootQueryResolver(
-      // info: GraphQLResolveInfo,
+      info: GraphQLResolveInfo,
       // ctx: ResolverContext,
     ) {
       const conn = await TypeORM.getConnection()
+      const relations = getRelationsForQuery(targetType, info)
+
       return conn.getRepository(targetType).find({
-        relations: targetTypeMetadata.relations,
+        relations,
       })
     }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,68 @@
+import { GraphQLResolveInfo, NameNode, SelectionNode, SelectionSetNode, FieldNode } from 'graphql'
+import { getConnection } from 'typeorm'
+
+function _getRelationsForSelectionSet<T>(
+  rootType: new () => T,
+  selectionSet: SelectionSetNode,
+): string[] {
+  const conn = getConnection()
+  const meta = conn.getMetadata(rootType)
+
+  const { relations } = meta
+  const relationStrings: string[] = []
+
+  selectionSet.selections.forEach((selection: SelectionNode) => {
+    if ('name' in selection) {
+      const name: NameNode = selection.name
+      const targetRelation = relations.find(relation =>
+        relation.propertyPath === name.value
+      )
+
+      if (targetRelation) {
+        relationStrings.push(targetRelation.propertyPath)
+
+        if ('selectionSet' in selection && selection.selectionSet) {
+          const subselections = _getRelationsForSelectionSet(
+            targetRelation.type as any,
+            selection.selectionSet,
+          )
+
+          subselections.forEach(
+            subselection => relationStrings.push(
+              `${targetRelation.propertyPath}.${subselection}`
+            ),
+          )
+        }
+      }
+    }
+  })
+
+  return relationStrings
+}
+
+function _getRelationsForFieldNode<T>(
+  rootType: new () => T,
+  fieldNode: FieldNode,
+): string[] {
+  const { selectionSet } = fieldNode
+
+  if (selectionSet) {
+    return _getRelationsForSelectionSet(
+      rootType,
+      selectionSet,
+    )
+  }
+  return []
+}
+
+export function getRelationsForQuery<T>(
+  rootType: new () => T,
+  info: GraphQLResolveInfo,
+) {
+  return info.fieldNodes.reduce<string[]>((relations, fieldNode) => {
+    return relations.concat(_getRelationsForFieldNode(
+      rootType,
+      fieldNode,
+    ))
+  }, [])
+}


### PR DESCRIPTION
# Update
We can now handle queries like this. 
```graphql
query {
  users {
    id
    posts {
      id
      user {
        id
        posts {
          title
        }
      }
    }
  }
}
```

It simply wraps TypeORM's `find` with `relations`. For each root query, it will inspect query selection tree and entity's metadata and make strings for `relations` so that everything is loaded at a single `find` operation.

For the example above, TypeORM operation will be executed like below.

```typescript
connection.getRepository(User).find({
  relations: [
    'posts',
    'posts.user',
    'posts.user.posts',
  ]
})
```

# Misc
- 1cc4b74 Add `README.md`.
- 9ff8a5c Make `DatebaseObjectType` options to be fully optional.