### PR TITLE
Apply noUnusedLocals and noUnusedParameters to tsconfig

### DIFF
--- a/__tests__/test-basic.ts
+++ b/__tests__/test-basic.ts
@@ -1,5 +1,3 @@
-import { getConnection } from 'typeorm'
-
 import { Post } from './entities/post'
 import { User } from './entities/user'
 import { query, setupTest, create } from './util'

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,5 +19,10 @@ module.exports = {
     '@/(.*)$': '<rootDir>/src/$1'
   },
   testEnvironment: 'node',
-  testPathIgnorePatterns: ['/node_modules/', '/lib/']
+  testPathIgnorePatterns: ['/node_modules/', '/lib/'],
+  globals: {
+    'ts-jest': {
+      tsConfig: './tsconfig.test.json'
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "type-graph-orm",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "repository": "github:JeongHoJeong/type-graph-orm",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
     "outDir": ".build",
     "declaration": true,
     "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "alwaysStrict": true,
     "strict": true,
     "emitDecoratorMetadata": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  }
+}


### PR DESCRIPTION
- Set `noUnusedLocals` and `noUnusedParameters` for better lint.
- For rapid test iteration, however, `noUnusedLocals` and `noUnusedParameters` options are better be turned off. Thus separate `tsconfig.test.json` is used for the test.