### PR TITLE
Implement field computed with subquery

### DIFF
--- a/__tests__/entities/post.ts
+++ b/__tests__/entities/post.ts
@@ -1,7 +1,9 @@
-import { Column, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { Column, ManyToOne, PrimaryGeneratedColumn, OneToMany } from 'typeorm'
 
 import * as GraphORM from '@/index'
+
 import { User } from './user'
+import { UserLikesPost } from './user-likes-post'
 
 @GraphORM.DatabaseObjectType({
   queryFieldName: 'posts'
@@ -18,4 +20,16 @@ export class Post {
 
   @ManyToOne(() => User, user => user.posts)
   public user: User
+
+  @Column({ nullable: true })
+  @GraphORM.Field({
+    addSelect: (sq, _, alias) =>
+      sq.select('COUNT(*)', 'count')
+        .from(UserLikesPost, 'userLikesPost')
+        .where(`"userLikesPost"."postId" = ${alias}.id`),
+  })
+  public totalLikes?: number
+
+  @OneToMany(() => UserLikesPost, like => like.post)
+  public userLikesPosts: UserLikesPost[]
 }

--- a/__tests__/entities/user-likes-post.ts
+++ b/__tests__/entities/user-likes-post.ts
@@ -1,0 +1,17 @@
+import { ManyToOne } from 'typeorm'
+
+import * as GraphORM from '@/index'
+
+import { User } from './user'
+import { Post } from './post'
+
+@GraphORM.DatabaseObjectType({
+  queryFieldName: 'userLikesPosts'
+})
+export class UserLikesPost {
+  @ManyToOne(() => User, { primary: true })
+  public user: User
+
+  @ManyToOne(() => Post, { primary: true })
+  public post: Post
+}

--- a/__tests__/entities/user.ts
+++ b/__tests__/entities/user.ts
@@ -1,7 +1,9 @@
 import { Column, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
 
 import * as GraphORM from '@/index'
+
 import { Post } from './post'
+import { UserLikesPost } from './user-likes-post'
 
 @GraphORM.DatabaseObjectType({
   queryFieldName: 'users'
@@ -18,4 +20,7 @@ export class User {
 
   @OneToMany(() => Post, post => post.user)
   public posts: Post[]
+
+  @OneToMany(() => UserLikesPost, like => like.user)
+  public userLikesPosts: UserLikesPost[]
 }

--- a/__tests__/test-subquery.ts
+++ b/__tests__/test-subquery.ts
@@ -1,0 +1,101 @@
+import { setupTest, create, query } from './util'
+import { User } from './entities/user'
+import { Post } from './entities/post'
+import { UserLikesPost } from './entities/user-likes-post'
+
+describe('Subquery', () => {
+  setupTest()
+
+  async function setupFixture() {
+    const userFoo = await create(User, {age: 20, name: 'foo'})
+    const userBar = await create(User, {age: 20, name: 'bar'})
+
+    const postFoo = await create(Post, {user: userFoo, title: 'foo post'})
+    const postBar = await create(Post, {user: userBar, title: 'bar post'})
+
+    await create(UserLikesPost, { user: userFoo, post: postFoo })
+    await create(UserLikesPost, { user: userBar, post: postFoo })
+    await create(UserLikesPost, { user: userBar, post: postBar })
+  }
+
+  beforeEach(async () => {
+    await setupFixture()
+  })
+
+  it('resolves fields calculated with subqueries', async () => {
+    const result = await query(`
+      query {
+        posts {
+          title
+          totalLikes
+          userLikesPosts {
+            user {
+              name
+            }
+          }
+        }
+      }`
+    )
+
+    expect(result.data!.posts).toHaveLength(2)
+    expect(result).toMatchObject({
+      data: {
+        posts: expect.arrayContaining([
+          {
+            title: 'foo post',
+            totalLikes: 2,
+            userLikesPosts: expect.arrayContaining([
+              {
+                user: {
+                  name: 'foo',
+                },
+              },
+              {
+                user: {
+                  name: 'bar'
+                },
+              },
+            ]),
+          },
+          {
+            title: 'bar post',
+            totalLikes: 1,
+            userLikesPosts: [
+              {
+                user: {
+                  name: 'bar',
+                },
+              }
+            ],
+          },
+        ])
+      },
+    })
+  })
+
+  it('resolves nested subqueries', async () => {
+    const result = await query(`
+      query {
+        users(where: { name: "foo" }) {
+          posts {
+            totalLikes
+          }
+        }
+      }
+    `)
+
+    expect(result).toMatchObject({
+      data: {
+        users: [
+          {
+            posts: [
+              {
+                totalLikes: 2,
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+})

--- a/__tests__/util.ts
+++ b/__tests__/util.ts
@@ -6,6 +6,7 @@ import { buildExecutableSchema } from '@/schema'
 
 import { Post } from './entities/post'
 import { User } from './entities/user'
+import { UserLikesPost } from './entities/user-likes-post'
 
 let conn: Connection | undefined
 export let schema: GraphQLSchema | undefined
@@ -14,13 +15,16 @@ export function setupTest() {
   dotenv.config()
 
   beforeAll(async () => {
+    const entities = [
+      User,
+      Post,
+      UserLikesPost,
+    ]
+
     if (!conn) {
       conn = await createConnection({
         database: process.env.TEST_DB_NAME,
-        entities: [
-          User,
-          Post,
-        ],
+        entities,
         host: process.env.TEST_DB_HOST,
         port: parseInt(process.env.TEST_DB_PORT || '5432', 10),
         type: process.env.TEST_DB_TYPE as any,
@@ -30,10 +34,7 @@ export function setupTest() {
 
     if (!schema) {
       schema = buildExecutableSchema({
-        entities: [
-          User,
-          Post,
-        ],
+        entities,
       })
     }
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "type-graph-orm",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "repository": "github:JeongHoJeong/type-graph-orm",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,10 @@ type FieldQueryBuilder<T, C> = (
   qb: TypeORM.SelectQueryBuilder<T>,
   ctx: C,
 ) => TypeORM.SelectQueryBuilder<T>
-type ResultToProperty = (data: any) => any
 
 interface Field<T, C> {
   propertyKey: string
   addSelect: FieldQueryBuilder<T, C>
-  resultToProperty: ResultToProperty
-  typeFunc: () => (new () => {})
 }
 
 interface DatabaseObjectMetadata<T, C> {
@@ -39,9 +36,7 @@ export function getDatabaseObjectMetadata<T, C>(target: object): DatabaseObjectM
 }
 
 export function Field<T, C>(options: {
-  typeFunc: () => any
   addSelect: FieldQueryBuilder<T, C>
-  resultToProperty(data: any): any
 }): PropertyDecorator {
   return (...args: Parameters<PropertyDecorator>): void => {
     const [target, propertyKey] = args

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,13 @@ type FieldQueryBuilder<T, C> = (
   ctx: C,
 ) => TypeORM.SelectQueryBuilder<T>
 
-interface Field<T, C> {
+export interface TypeGraphORMField<T, C> {
   propertyKey: string
   addSelect: FieldQueryBuilder<T, C>
 }
 
 interface DatabaseObjectMetadata<T, C> {
-  fields: Field<T, C>[]
+  fields: TypeGraphORMField<T, C>[]
   queryFieldName?: string
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ const databaseObjectMetadataKey = Symbol('databaseObjectMetadataKey')
 type FieldQueryBuilder<T, C> = (
   qb: TypeORM.SelectQueryBuilder<T>,
   ctx: C,
+  alias: string,
 ) => TypeORM.SelectQueryBuilder<T>
 
 export interface TypeGraphORMField<T, C> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ type FieldQueryBuilder<T, C> = (
 type ResultToProperty = (data: any) => any
 
 interface Field<T, C> {
-  propertyKey: string | symbol
+  propertyKey: string
   addSelect: FieldQueryBuilder<T, C>
   resultToProperty: ResultToProperty
   typeFunc: () => (new () => {})
@@ -46,10 +46,13 @@ export function Field<T, C>(options: {
   return (...args: Parameters<PropertyDecorator>): void => {
     const [target, propertyKey] = args
     const metadata = getDatabaseObjectMetadata<T, C>(target)
-    metadata.fields.push({
-      ...options,
-      propertyKey,
-    })
+
+    if (typeof propertyKey === 'string') {
+      metadata.fields.push({
+        ...options,
+        propertyKey,
+      })
+    }
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,7 @@ import { getConnection } from 'typeorm'
 export interface Relation {
   relationPath: string
   fieldNode: FieldNode
+  type: string | Function
 }
 
 function _getRelationsForFieldNode<T>(
@@ -31,6 +32,7 @@ function _getRelationsForFieldNode<T>(
             results.push({
               relationPath: targetRelation.propertyPath,
               fieldNode: selection,
+              type: targetRelation.type,
             })
 
             if ('selectionSet' in selection && selection.selectionSet) {
@@ -43,6 +45,7 @@ function _getRelationsForFieldNode<T>(
                 subselection => results.push({
                   relationPath: `${targetRelation.propertyPath}.${subselection.relationPath}`,
                   fieldNode: subselection.fieldNode,
+                  type: subselection.type,
                 }),
               )
             }


### PR DESCRIPTION
- Now we can define fields computed via subquery, computed efficiently via single database query.
```typescript
class Post {

  // ...

  @Column({ nullable: true })
  @GraphORM.Field({
    addSelect: (sq, _, alias) =>
      sq.select('COUNT(*)', 'count')
        .from(UserLikesPost, 'userLikesPost')
        .where(`"userLikesPost"."postId" = ${alias}.id`),
  })
  public totalLikes?: number
  
  // ...

}
```
- To implement fields computed by subqueries, without using `getRawMany`, `@Column` decorator is required. This will introduce unnecessary column addition. Except that, however, this is the fastest way to implement this feature. These problems should be tackled in the future.