### PR TITLE
Implement views

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   plugins: ['@typescript-eslint'],
   extends: ['plugin:@typescript-eslint/recommended'],
   rules: {
+    'max-len': ['error', {'code': 120}],
     '@typescript-eslint/indent': ['error', 2],
     '@typescript-eslint/semi': ['error', 'never'],
     '@typescript-eslint/member-delimiter-style': ['error', {
@@ -12,6 +13,7 @@ module.exports = {
     }],
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
     'no-console': ['warn'],
   }
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ import { graphql } from 'graphql'
 
 // Define TypeORM entities
 @GraphORM.DatabaseObjectType({
-  queryFieldName: 'users'
+  views: [{
+    // API users can directly query `users` field via this *view*.
+    isDirectView: true,
+    name: 'users'
+  }]
 })
 export class User {
   @PrimaryGeneratedColumn()
@@ -33,9 +37,7 @@ export class User {
   public posts: Post[]
 }
 
-@GraphORM.DatabaseObjectType({
-  queryFieldName: 'posts'
-})
+@GraphORM.DatabaseObjectType()
 class Post {
   @PrimaryGeneratedColumn()
   public id: number
@@ -55,19 +57,33 @@ const schema = await buildExecutableSchema({
   ],
 })
 
-// Run query!
+// Simple query
 const result = await graphql(schema, `
-query {
-  users {
-    id
-    name
-    age
-    posts {
+  query {
+    users {
       id
-      title
+      name
+      age
+      posts {
+        id
+        title
+      }
     }
-  }
-}`)
+  }`
+)
+
+// Complex filters
+const result = await graphql(schema, `
+  query {
+    users(where: {name: "Foo"}) {
+      id
+      age
+      posts(where: {id: 2}) {
+        title
+      }
+    }
+  }`
+)
 ```
 
 ## Notes

--- a/__tests__/entities/post.ts
+++ b/__tests__/entities/post.ts
@@ -6,7 +6,10 @@ import { User } from './user'
 import { UserLikesPost } from './user-likes-post'
 
 @GraphORM.DatabaseObjectType({
-  queryFieldName: 'posts'
+  views: [{
+    name: 'posts',
+    isDirectView: true,
+  }],
 })
 export class Post {
   @PrimaryGeneratedColumn()

--- a/__tests__/entities/user-likes-post.ts
+++ b/__tests__/entities/user-likes-post.ts
@@ -5,9 +5,7 @@ import * as GraphORM from '@/index'
 import { User } from './user'
 import { Post } from './post'
 
-@GraphORM.DatabaseObjectType({
-  queryFieldName: 'userLikesPosts'
-})
+@GraphORM.DatabaseObjectType()
 export class UserLikesPost {
   @ManyToOne(() => User, { primary: true })
   public user: User

--- a/__tests__/entities/user.ts
+++ b/__tests__/entities/user.ts
@@ -1,4 +1,5 @@
-import { Column, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
+import { Column, OneToMany, PrimaryGeneratedColumn, getConnection } from 'typeorm'
+import { GraphQLInt } from 'graphql'
 
 import * as GraphORM from '@/index'
 
@@ -6,7 +7,32 @@ import { Post } from './post'
 import { UserLikesPost } from './user-likes-post'
 
 @GraphORM.DatabaseObjectType({
-  queryFieldName: 'users'
+  views: [{
+    name: 'users',
+    isDirectView: true,
+  }, {
+    name: 'searchUsers',
+    args: {
+      age: {
+        type: GraphQLInt,
+      },
+    },
+    getIds: async ({
+      args,
+    }) => {
+      const conn = getConnection()
+      const users = await conn.getRepository(User).find({  // eslint-disable-line
+        where: {
+          age: args.age,
+        },
+        order: {
+          name: 'ASC',
+        },
+      })
+
+      return users.map(user => user.id)
+    },
+  }],
 })
 export class User {
   @PrimaryGeneratedColumn()

--- a/__tests__/test-view.ts
+++ b/__tests__/test-view.ts
@@ -1,0 +1,74 @@
+import { User } from './entities/user'
+import { query, setupTest, create } from './util'
+import { Post } from './entities/post'
+
+describe('View', () => {
+  setupTest()
+
+  async function setupFixture() {
+    await create(User, {name: 'E', age: 30})
+    await create(User, {name: 'C', age: 30})
+    await create(User, {name: 'D', age: 20})
+    await create(User, {name: 'A', age: 30})
+    const userB = await create(User, {name: 'B', age: 25})
+
+    await create(Post, { user: userB, title: 'X' })
+    await create(Post, { user: userB, title: 'Y' })
+  }
+
+  beforeEach(async () => {
+    await setupFixture()
+  })
+
+  it('handles view', async () => {
+    const result = await query(`
+      query {
+        searchUsers(age: 30) {
+          name
+          age
+        }
+      }`
+    )
+
+    expect(result.data && result.data.searchUsers).toMatchObject([
+      {
+        name: 'A',
+        age: 30,
+      },
+      {
+        name: 'C',
+        age: 30,
+      },
+      {
+        name: 'E',
+        age: 30,
+      },
+    ])
+  })
+
+  it('handles multi-depth query', async () => {
+    const result = await query(`
+      query {
+        searchUsers(age: 25) {
+          name
+          age
+          posts(where: {title: "X"}) {
+            title
+          }
+        }
+      }
+    `)
+
+    expect(result.data && result.data.searchUsers).toMatchObject([
+      {
+        name: 'B',
+        age: 25,
+        posts: [
+          {
+            title: 'X',
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "type-graph-orm",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "repository": "github:JeongHoJeong/type-graph-orm",

--- a/src/order.ts
+++ b/src/order.ts
@@ -5,23 +5,27 @@ import { SchemaInfo } from './schema'
 
 const orderTypes = ['ASC', 'DESC']
 
-export function orderNamesToOrderInfos(orderNames: string[]): ({
+export interface OrderInfo {
   propertyName: string
-  orderType: 'ASC' | 'DESC'
-} | undefined)[] {
-  return orderNames.map(orderName => {
+  type: 'ASC' | 'DESC'
+}
+
+export function orderNamesToOrderInfos(orderNames: string[]): OrderInfo[] {
+  return orderNames.reduce<OrderInfo[]>((result, orderName) => {
     const splitted = orderName.split('_')
     const { length } = splitted
     if (length > 0) {
-      const orderType = splitted[splitted.length - 1]
-      if (orderType === 'ASC' || orderType === 'DESC') {
-        return {
+      const type = splitted[splitted.length - 1]
+      if (type === 'ASC' || type === 'DESC') {
+        result.push({
           propertyName: splitted.slice(0, length - 1).join('_'),
-          orderType,
-        }
+          type,
+        })
       }
     }
-  })
+
+    return result
+  }, [])
 }
 
 export function createOrderByInput(schemaInfo: SchemaInfo, entity: any): GraphQLEnumType {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,0 +1,125 @@
+import * as TypeORM from 'typeorm'
+import { GraphQLResolveInfo } from 'graphql'
+
+import { getRelationsForQuery, graphQLObjectValueToObject } from './util'
+import { TypeGraphORMField, getDatabaseObjectMetadata } from '.'
+import { translateWhereClause, Where } from './where'
+import { orderNamesToOrderInfos, OrderInfo } from './order'
+
+function addSubqueries(
+  qb: TypeORM.SelectQueryBuilder<any>,
+  fields: TypeGraphORMField<any, any>[],
+  alias: string,
+) {
+  fields.forEach(field => {
+    if (field.addSelect) {
+      qb.addSelect(
+        sq => field.addSelect(sq, {}, alias),
+        `${alias}_${field.propertyKey}`,
+      )
+    }
+  })
+}
+
+export async function resolve({
+  entity,
+  where,
+  info,
+  take,
+  skip,
+  orders,
+  ids,
+}: {
+  entity: any
+  info: GraphQLResolveInfo
+  where?: Where
+  skip?: number
+  take?: number
+  orders?: OrderInfo[]
+  ids?: any[]
+}) {
+  const meta = getDatabaseObjectMetadata(entity.prototype)
+  const _conn = TypeORM.getConnection()
+  const typeormMetadata = _conn.getMetadata(entity)
+  const { name } = typeormMetadata
+  const relations = getRelationsForQuery(entity, info)
+
+  const qb = _conn.getRepository(entity).createQueryBuilder()
+
+  relations.forEach(relation => {
+    if (typeof relation.type === 'string') {
+      // TODO: support string typed relation
+      throw new Error(`String typed relation is not supported yet.`)
+    } else {
+      const relationMeta = getDatabaseObjectMetadata(relation.type.prototype)
+
+      const entities = relation.relationPath.split('.')
+      const lastPath = entities[entities.length - 1]
+      const prevEntities = [typeormMetadata.name].concat(entities.slice(0, entities.length - 1))
+
+      const joinPath = `${prevEntities.join('_')}.${lastPath}`
+      const alias = `${prevEntities.join('_')}_${lastPath}`
+
+      addSubqueries(qb, relationMeta.fields, alias)
+
+      const { arguments: fieldArgs } = relation.fieldNode
+
+      if (fieldArgs) {
+        const [clause, params] = (() => {
+          const whereArg = fieldArgs.find(arg => arg.name.value === 'where')
+
+          if (whereArg) {
+            const whereArgObject = graphQLObjectValueToObject(whereArg.value)
+            return translateWhereClause(
+              alias,
+              whereArgObject,
+              relation.relationPath,
+            )
+          }
+          return []
+        })()
+        qb.leftJoinAndSelect(joinPath, alias, clause, params)
+
+        const orderByArg = fieldArgs.find(arg => arg.name.value === 'orderBy')
+
+        if (orderByArg) {
+          const orderByArgObject = graphQLObjectValueToObject(orderByArg.value)
+          const orderByNames = orderByArgObject instanceof Array ? orderByArgObject : [orderByArgObject]
+          const orders = orderNamesToOrderInfos(orderByNames)
+          orders.forEach(order => {
+            if (order) {
+              qb.addOrderBy(`${alias}.${order.propertyName}`, order.type)
+            }
+          })
+        }
+      }
+    }
+  })
+
+  addSubqueries(qb, meta.fields, typeormMetadata.name)
+
+  if (ids) {
+    qb.whereInIds(ids)
+  } else if (where) {
+    const [ clause, params ] = where
+    qb.where(clause, params)
+  }
+
+  if (orders) {
+    orders.forEach(order => {
+      if (order) {
+        qb.addOrderBy(`${name}.${order.propertyName}`, order.type)
+      }
+    })
+  }
+
+  if (take) {
+    qb.take(take)
+  }
+
+  if (skip) {
+    qb.skip(skip)
+  }
+
+  return qb.getMany()
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 import { GraphQLResolveInfo, NameNode, SelectionNode, FieldNode, ValueNode } from 'graphql'
 import { getConnection } from 'typeorm'
+import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata'
 
 export interface Relation {
   relationPath: string
@@ -92,4 +93,35 @@ export function graphQLObjectValueToObject(value: ValueNode) {
       return values
     }, [])
   }
+}
+
+export function orderItemsByPrimaryColumns<T>(
+  primaryColumns: ColumnMetadata[],
+  items: T[],
+  ids: any[],
+): T[] {
+  const [primaryColumn] = primaryColumns
+
+  if (primaryColumn) {
+    const { propertyName } = primaryColumn
+
+    const idToItemMap = items.reduce<any>((map, item) => {
+      if (propertyName in item) {
+        const id = (item as any)[propertyName]
+        map[id] = item
+      }
+      return map
+    }, {})
+
+    const ordered = ids.reduce<T[]>((array, id) => {
+      if (id in idToItemMap) {
+        array.push(idToItemMap[id])
+      }
+      return array
+    }, [])
+
+    return ordered
+  }
+
+  return items
 }

--- a/src/where.ts
+++ b/src/where.ts
@@ -37,11 +37,13 @@ function combineParams(params: {[key: string]: any}[]) {
   }, {})
 }
 
+export type Where = [string, {[key: string]: any}]
+
 export function translateWhereClause(
   entity: string,
   where: any,
   conditionPrefix: string = '',
-): [string, {[key: string]: any}] {
+): Where {
   const clauses = Object.keys(where).reduce<[string, {[key: string]: any}][]>(
     (_clauses, key) => {
       const uniqueKey = `${conditionPrefix}_${key}`

--- a/src/where.ts
+++ b/src/where.ts
@@ -1,5 +1,8 @@
 import * as TypeORM from 'typeorm'
-import { GraphQLInputObjectType, GraphQLInputObjectTypeConfig, GraphQLInt, GraphQLInputFieldConfigMap, GraphQLList, GraphQLFieldConfigArgumentMap } from 'graphql'
+import {
+  GraphQLInputObjectType, GraphQLInputObjectTypeConfig, GraphQLInt, GraphQLInputFieldConfigMap, GraphQLList,
+  GraphQLFieldConfigArgumentMap,
+} from 'graphql'
 import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata'
 
 import { typeORMColumnTypeToGraphQLInputType } from './type'


### PR DESCRIPTION
For details, see commit message of: 5a100f8

Now it's able to restrict what to show according to the context(viewer) and given arguments. The example below defines a *view* that shows records filtered with custom logic.

```typescript
@GraphORM.DatabaseObjectType({
  views: [{
    name: 'searchUsers',
    args: {
      age: {
        type: GraphQLInt,
      },
    },
    getIds: async ({
      args,
    }) => {
      const conn = getConnection()
      const users = await conn.getRepository(User).find({
        where: {
          age: args.age,
        },
        order: {
          name: 'ASC',
        },
      })

      return users.map(user => user.id)
    },
  }],
})
export class User {
  /* ... */
}

await query(schema, `
  query {
    searchUsers(age: 20) {
      id
    }
  }
`)
```