### PR TITLE
Allow string type for field definition

### DIFF
--- a/__tests__/entities/user.ts
+++ b/__tests__/entities/user.ts
@@ -107,4 +107,27 @@ export class User {
     },
   })
   public reversedName: string
+
+  @GraphORM.Field<User, {}>({
+    type: 'Post',
+    async resolve(source) {
+      const mostRecentPost = await getRepository(Post).findOne({
+        order: {
+          id: 'DESC',
+        },
+        where: {
+          user: {
+            id: source.id,
+          },
+        }
+      })
+
+      if (mostRecentPost) {
+        return {
+          id: mostRecentPost.id,
+        }
+      }
+    }
+  })
+  public mostRecentPost?: Post
 }

--- a/__tests__/test-context.ts
+++ b/__tests__/test-context.ts
@@ -6,7 +6,7 @@ import { UserLikesPost } from '__tests__/entities/user-likes-post'
 describe('Context', () => {
   setupTest()
 
-  it('handles OR clause', async () => {
+  it('passes context to the resolver', async () => {
     const userFoo = await create(User, {age: 20, name: 'foo'})
     const userBar = await create(User, {age: 30, name: 'bar'})
     const postFoo = await create(Post, {user: userFoo, title: 'foo post'})

--- a/__tests__/test-string-typed-field.ts
+++ b/__tests__/test-string-typed-field.ts
@@ -1,0 +1,33 @@
+import { User } from '__tests__/entities/user'
+import { Post } from '__tests__/entities/post'
+import { query, setupTest, create } from '__tests__/util'
+
+describe('String typed field', () => {
+  setupTest()
+
+  it('handles string typed field', async () => {
+    const user = await create(User, {age: 20, name: 'foo'})
+    await create(Post, {user: user, title: 'foo post'})
+    const postBar = await create(Post, {user: user, title: 'bar post'})
+
+    const result = await query(
+      `{
+        users {
+          mostRecentPost {
+            id
+            title
+          }
+        }
+      }`
+    )
+
+    expect(result.data).toMatchObject({
+      users: [{
+        mostRecentPost: {
+          id: postBar.id,
+          title: 'bar post',
+        }
+      }]
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "type-graph-orm",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "repository": "github:JeongHoJeong/type-graph-orm",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export interface TypeGraphORMField<T, C> {
   propertyKey: string
   nullable?: boolean
   resolve?: GraphQLFieldResolver<T, C>
-  type?: GraphQLOutputType
+  type?: GraphQLOutputType | string
   addSelect?: FieldQueryBuilder<T, C>
 }
 
@@ -42,12 +42,14 @@ export function getDatabaseObjectMetadata<T, C>(target: object): DatabaseObjectM
   }
 }
 
-export function Field<T, C>(options: {
+interface FieldOptions<T, C> {
   addSelect?: FieldQueryBuilder<T, C>
   resolve?: GraphQLFieldResolver<T, C>
-  type?: GraphQLOutputType
+  type?: GraphQLOutputType | string
   nullable?: boolean
-}): PropertyDecorator {
+}
+
+export function Field<T, C>(options: FieldOptions<T, C>): PropertyDecorator {
   return (...args: Parameters<PropertyDecorator>): void => {
     const [target, propertyKey] = args
     const metadata = getDatabaseObjectMetadata<T, C>(target)


### PR DESCRIPTION
Since some field types returns some entity types, which is defined later, we need to address those types without direct object reference. Here I'm using string literal to address which type it should return.